### PR TITLE
Fix "more optimal"

### DIFF
--- a/content/guide-render-pass-framebuffer.md
+++ b/content/guide-render-pass-framebuffer.md
@@ -51,7 +51,7 @@ pass (ie. fill it with a single color), while `store: Store` indicates that we w
 actually store the output of our draw commands to the image.
 
 > **Note**: It is possible to create temporary images whose content is only relevant inside of a
-> render pass, in which case it is more optimal to use `store: DontCare` instead of `store: Store`.
+> render pass, in which case it is optimal to use `store: DontCare` instead of `store: Store`.
 
 ## Entering the render pass
 


### PR DESCRIPTION
Usage of "more optimal" is controversial and probably not entirely correct. The word "optimal" alone is sufficient in this context.