### PR TITLE
Diagrams in documentation are incorrectly clipped

### DIFF
--- a/content/guide-compute-pipeline.md
+++ b/content/guide-compute-pipeline.md
@@ -10,7 +10,7 @@ This is done in two steps:
 - At runtime we pass this *SPIR-V* to the Vulkan implementation, which in turn converts it into
   its own implementation-specific format.
 
-<center>![](/guide-compute-pipeline-1.svg)</center>
+<center><object data="/guide-compute-pipeline-1.svg"></object></center>
 
 > **Note**: In the very far future it may be possible to write programs in Rust, or in a
 > domain specific language that resembles Rust.

--- a/content/guide-descriptor-sets.md
+++ b/content/guide-descriptor-sets.md
@@ -23,7 +23,7 @@ What we declared in the GLSL code is actually not a descriptor set, but only a s
 descriptor set. Before we can invoke the compute pipeline, we first need to bind an actual
 descriptor set to that slot.
 
-<center>![](/guide-descriptor-sets-1.svg)</center>
+<center><object data="/guide-descriptor-sets-1.svg"></object></center>
 
 ## Creating a descriptor set
 

--- a/content/guide-fragment-shader.md
+++ b/content/guide-fragment-shader.md
@@ -7,7 +7,11 @@ modified on the final image.
 > **Note**: More precisely, it is only if the center of a pixel is within the triangle that the
 > GPU considers that the whole pixel is inside.
 
-<center>![Illustration of which pixels are inside the triangle](/guide-fragment-shader-1.svg)</center>
+<center>
+    <object data='/guide-fragment-shader-1.svg'>
+            alt='Illustration of which pixels are inside the triangle'
+    </object>
+</center>
 
 The GPU then takes each of these pixels one by one (the ones in red in the image above) and runs
 another type of shader named a **fragment shader** which we also need to provide in order to start

--- a/content/guide-memory.md
+++ b/content/guide-memory.md
@@ -15,7 +15,7 @@ video memory, but the read and write accesses are going to be much slower as the
 through the PCI Express bus that connects your video card to your motherboard.
 
 <center>
-![](/guide-buffer-creation-1.svg)
+<object data="/guide-buffer-creation-1.svg"></object>
 </center>
 
 > **Note**: All of this is true only for desktop machines with video cards, which is what we

--- a/content/guide-vertex-input.md
+++ b/content/guide-vertex-input.md
@@ -32,14 +32,14 @@ the image we are drawing to. Being a vectorial renderer, Vulkan doesn't use coor
 pixels. Instead it considers that the image has a width and a height of 2 units, and that the
 origin is at the center of the image.
 
-<center>![](/guide-vertex-input-1.svg)</center>
+<center><object data="/guide-vertex-input-1.svg"></object></center>
 
 When we give positions to Vulkan, we need to use its coordinate system.
 
 In this guide we are going to draw only a single triangle for now. Let's pick a shape for it,
 for example this one:
 
-<center>![](/guide-vertex-input-2.svg)</center>
+<center><object data="/guide-vertex-input-2.svg"></object></center>
 
 Which translates into this code:
 

--- a/static/guide-buffer-creation-1.svg
+++ b/static/guide-buffer-creation-1.svg
@@ -15,8 +15,11 @@
    version="1.1"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="guide-buffer-creation-1.svg">
-  <defs id="defs4734">
-    <style type="text/css">@import 'svg-styles.css';</style>
+  <defs
+     id="defs4734">
+    <style
+       type="text/css"
+       id="style2">@import 'svg-styles.css';</style>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -25,9 +28,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4"
-     inkscape:cx="-64.432523"
-     inkscape:cy="141.80221"
+     inkscape:zoom="6.5045477"
+     inkscape:cx="172.34731"
+     inkscape:cy="86.364751"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -57,153 +60,153 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(-267.43841,-479.20374)">
-    <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 273.28389,595.95469 0,38.52927 87.71793,0 0,-38.52927 z"
-       id="rect2985-9-5"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="293.46564"
-       y="623.54053"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="297.37845"
+       y="623.27228"
        id="text2987-2-1"><tspan
          sodipodi:role="line"
          id="tspan2989-4-7"
-         x="293.46564"
-         y="623.54053"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">CPU</tspan></text>
+         x="297.37845"
+         y="623.27228"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">CPU</tspan></text>
     <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 275.28389,488.81183 0,38.52927 87.71793,0 0,-38.52927 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 275.28389,488.81183 v 38.52927 h 87.71793 v -38.52927 z"
        id="rect2985-9-5-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="295.46564"
-       y="516.39771"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="294.84644"
+       y="516.15692"
        id="text2987-2-1-1"><tspan
          sodipodi:role="line"
          id="tspan2989-4-7-5"
-         x="295.46564"
-         y="516.39771"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">RAM</tspan></text>
-    <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 516.56961,595.9547 0,38.52927 87.71793,0 0,-38.52927 z"
-       id="rect2985-9-5-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+         x="294.84644"
+         y="516.15692"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">RAM</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="528.75134"
-       y="623.54053"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="530.52313"
+       y="623.2998"
        id="text2987-2-1-7"><tspan
          sodipodi:role="line"
          id="tspan2989-4-7-6"
-         x="528.75134"
-         y="623.54053"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">VRAM</tspan></text>
+         x="530.52313"
+         y="623.2998"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">VRAM</tspan></text>
     <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 518.56961,488.81183 0,38.52927 87.71793,0 0,-38.52927 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 275.28389,595.95469 v 38.52927 h 87.71793 v -38.52927 z"
+       id="rect2985-9-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 516.56961,595.9547 v 38.52927 h 87.71793 V 595.9547 Z"
+       id="rect2985-9-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 516.56961,488.81183 v 38.52927 h 87.71793 v -38.52927 z"
        id="rect2985-9-5-1-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="538.75134"
-       y="516.39771"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="537.56329"
+       y="516.12939"
        id="text2987-2-1-1-4"><tspan
          sodipodi:role="line"
          id="tspan2989-4-7-5-2"
-         x="538.75134"
-         y="516.39771"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">GPU</tspan></text>
+         x="537.56329"
+         y="516.12939"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">GPU</tspan></text>
     <path
-       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 315.71429,538.07647 0,45"
+       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 319.14285,539.1479 v 45"
        id="path4821"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 562.14286,537.71933 0,45"
+       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 560.42858,539.1479 v 45"
        id="path4821-3"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#ffffff;stroke-width:6.36180067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 495.83819,614.50503 -113.82894,0"
+       style="fill:none;stroke:#ffffff;stroke-width:6.36180067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 496.70018,614.50503 H 382.87124"
        id="path4821-2"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#ffffff;stroke-width:6.36180067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 497.62876,505.93361 -113.82894,0"
+       style="fill:none;stroke:#ffffff;stroke-width:6.36180067;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 496.70018,505.93361 H 382.87124"
        id="path4821-2-2"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        x="324.14288"
-       y="565.2193"
+       y="567.2807"
        id="text5374"><tspan
          sodipodi:role="line"
          id="tspan5376"
          x="324.14288"
-         y="565.2193"
-         style="font-size:16px;line-height:1.25;font-family:sans-serif">Fast</tspan></text>
+         y="567.2807"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Fast</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        x="522.40741"
-       y="564.42358"
+       y="567.2807"
        id="text5374-1"><tspan
          sodipodi:role="line"
          id="tspan5376-6"
          x="522.40741"
-         y="564.42358"
-         style="font-size:16px;line-height:1.25;font-family:sans-serif">Fast</tspan></text>
+         y="567.2807"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Fast</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="423.83594"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="421.98492"
        y="495.85217"
        id="text5374-8"><tspan
          sodipodi:role="line"
          id="tspan5376-5"
-         x="423.83594"
+         x="421.98492"
          y="495.85217"
-         style="font-size:16px;line-height:1.25;font-family:sans-serif">Slow</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Slow</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="438.77954"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="439.45367"
        y="605.66016"
        id="text5374-8-7"><tspan
          sodipodi:role="line"
-         x="438.77954"
+         x="439.45367"
          y="605.66016"
          id="tspan5431"
-         style="font-size:16px;line-height:1.25;font-family:sans-serif">Slow</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Slow</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="438.96207"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="439.6192"
        y="630.94592"
        id="text5374-8-1"><tspan
          sodipodi:role="line"
          id="tspan5376-5-8"
-         x="438.96207"
+         x="439.6192"
          y="630.94592"
-         style="font-size:11px;line-height:1.25;font-family:sans-serif">Sometimes not</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Sometimes not</tspan><tspan
          sodipodi:role="line"
-         x="438.96207"
+         x="439.6192"
          y="644.69592"
          id="tspan5449"
-         style="font-size:11px;line-height:1.25;font-family:sans-serif">even possible</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">even possible</tspan></text>
   </g>
 </svg>

--- a/static/guide-buffer-creation-1.svg
+++ b/static/guide-buffer-creation-1.svg
@@ -15,8 +15,9 @@
    version="1.1"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="guide-buffer-creation-1.svg">
-  <defs
-     id="defs4734" />
+  <defs id="defs4734">
+    <style type="text/css">@import 'svg-styles.css';</style>
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#000000"

--- a/static/guide-compute-pipeline-1.svg
+++ b/static/guide-compute-pipeline-1.svg
@@ -39,6 +39,7 @@
      inkscape:window-maximized="1" />
   <defs
      id="defs4">
+    <style type="text/css">@import 'svg-styles.css';</style>
     <marker
        style="overflow:visible"
        id="Arrow1Mend"

--- a/static/guide-compute-pipeline-1.svg
+++ b/static/guide-compute-pipeline-1.svg
@@ -9,8 +9,8 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="693.64813"
-   height="154.31203"
+   width="708.47626"
+   height="164.63101"
    id="svg2"
    version="1.1"
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
@@ -22,16 +22,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.98994949"
-     inkscape:cx="241.12949"
-     inkscape:cy="138.82029"
+     inkscape:zoom="3.0910988"
+     inkscape:cx="363.0101"
+     inkscape:cy="86.252663"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     fit-margin-top="0.5"
-     fit-margin-left="0.5"
-     fit-margin-right="0.5"
-     fit-margin-bottom="0.5"
+     fit-margin-top="2"
+     fit-margin-left="2"
+     fit-margin-right="2"
+     fit-margin-bottom="2"
      inkscape:window-width="3840"
      inkscape:window-height="2031"
      inkscape:window-x="0"
@@ -39,7 +39,9 @@
      inkscape:window-maximized="1" />
   <defs
      id="defs4">
-    <style type="text/css">@import 'svg-styles.css';</style>
+    <style
+       type="text/css"
+       id="style36">@import 'svg-styles.css';</style>
     <marker
        style="overflow:visible"
        id="Arrow1Mend"
@@ -50,8 +52,8 @@
       <path
          inkscape:connector-curvature="0"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          id="path4034" />
     </marker>
     <marker
@@ -64,8 +66,8 @@
       <path
          inkscape:connector-curvature="0"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          id="path4028" />
     </marker>
     <marker
@@ -77,8 +79,8 @@
        inkscape:stockid="Arrow1Mend">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          id="path4034-8"
          inkscape:connector-curvature="0" />
     </marker>
@@ -91,8 +93,8 @@
        inkscape:stockid="Arrow1Mend-8S">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000003pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          id="path3995"
          inkscape:connector-curvature="0" />
     </marker>
@@ -105,8 +107,8 @@
        inkscape:stockid="Arrow1Mend-8k">
       <path
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         style="fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000003pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          id="path3998"
          inkscape:connector-curvature="0" />
     </marker>
@@ -119,12 +121,12 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-111.73553,-239.429)"
+     transform="translate(-110.54803,-229.87856)"
      id="layer1"
      inkscape:groupmode="layer"
      inkscape:label="Calque 1">
@@ -132,101 +134,101 @@
        id="text2985"
        y="370.50922"
        x="110.10663"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          y="370.50922"
          x="110.10663"
          id="tspan2987"
          sodipodi:role="line"
-         style="font-size:40px;line-height:1.25;font-family:sans-serif">GLSL</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">GLSL</tspan></text>
     <text
        id="text2985-4"
        y="370.50922"
        x="350.10663"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          y="370.50922"
          x="350.10663"
          id="tspan2987-0"
          sodipodi:role="line"
-         style="font-size:40px;line-height:1.25;font-family:sans-serif">SPIR-V</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">SPIR-V</tspan></text>
     <text
        id="text2985-4-9"
        y="370.50922"
        x="618.10663"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          y="370.50922"
          x="618.10663"
          id="tspan2987-0-4"
          sodipodi:role="line"
-         style="font-size:40px;line-height:1.25;font-family:sans-serif">???</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">???</tspan></text>
     <text
        id="text3063"
        y="388.71228"
        x="612.27429"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          id="tspan3067"
          y="388.71228"
          x="612.27429"
          sodipodi:role="line"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(implementation-specific detail)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(implementation-specific detail)</tspan></text>
     <path
        inkscape:connector-curvature="0"
        id="path3071"
-       d="m 230.33509,355.35693 94.95433,0"
-       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-mid:none;marker-end:url(#Arrow1Mend-8S)" />
+       d="m 230.33509,355.35693 h 94.95433"
+       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-mid:none;marker-end:url(#Arrow1Mend-8S)" />
     <path
        inkscape:connector-curvature="0"
        id="path3071-2"
-       d="m 504.33509,355.35693 94.95433,0"
-       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-mid:none;marker-end:url(#Arrow1Mend-8k)" />
+       d="m 504.33509,355.35693 h 94.95433"
+       style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-mid:none;marker-end:url(#Arrow1Mend-8k)" />
     <text
        transform="rotate(-63.039481)"
        id="text4675"
        y="384.91385"
        x="-192.2471"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          y="384.91385"
          x="-192.2471"
          id="tspan4677"
          sodipodi:role="line"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">During compilation</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">During compilation</tspan></text>
     <text
        transform="rotate(-63.039481)"
        id="text4675-4"
        y="634.0318"
        x="-64.72538"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          y="634.0318"
          x="-64.72538"
          id="tspan4677-5"
          sodipodi:role="line"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">At runtime</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">At runtime</tspan></text>
     <text
        id="text3063-5"
        y="390.29474"
        x="115.8045"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          id="tspan4721"
          y="390.29474"
          x="115.8045"
          sodipodi:role="line"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(source code)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(source code)</tspan></text>
     <text
        id="text3063-5-7"
        y="388.315"
        x="306.21524"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
        xml:space="preserve"><tspan
          id="tspan4721-1"
          y="388.315"
          x="306.21524"
          sodipodi:role="line"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(binary intermediate representation)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(binary intermediate representation)</tspan></text>
   </g>
 </svg>

--- a/static/guide-descriptor-sets-1.svg
+++ b/static/guide-descriptor-sets-1.svg
@@ -17,7 +17,9 @@
    sodipodi:docname="guide-descriptor-sets-1.svg">
   <defs
      id="defs4">
-    <style type="text/css">@import 'svg-styles.css';</style>
+    <style
+       type="text/css"
+       id="style70">@import 'svg-styles.css';</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"
@@ -27,8 +29,8 @@
        style="overflow:visible">
       <path
          id="path3865"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
          transform="matrix(0.4,0,0,0.4,4,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -41,8 +43,8 @@
        style="overflow:visible">
       <path
          id="path3859"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt"
          transform="matrix(0.8,0,0,0.8,10,0)"
          inkscape:connector-curvature="0" />
     </marker>
@@ -54,9 +56,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.7"
-     inkscape:cx="-374.36622"
-     inkscape:cy="249.66167"
+     inkscape:zoom="3.0916455"
+     inkscape:cx="134.86496"
+     inkscape:cy="203.15515"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -77,7 +79,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -87,23 +89,23 @@
      id="layer1"
      transform="translate(-170.35044,-117.13088)">
     <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 235.92346,466.70926 0,53.88645 201.31142,0 0,-53.88645 -148.64529,0 0,8.18204 -31.01841,0 0,-8.18204 -21.64772,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 235.92346,466.70926 v 53.88645 H 437.23488 V 466.70926 H 288.58959 v 8.18204 h -31.01841 v -8.18204 z"
        id="rect2985"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="249.29256"
-       y="501.66348"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="243.05386"
+       y="501.17831"
        id="text2987"><tspan
          sodipodi:role="line"
          id="tspan2989"
-         x="249.29256"
-         y="501.66348"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">Compute pipeline</tspan></text>
+         x="243.05386"
+         y="501.17831"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Compute pipeline</tspan></text>
     <rect
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect3759"
        width="31.030846"
        height="61.810425"
@@ -111,78 +113,78 @@
        y="412.79843" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="-468.68051"
-       y="279.15356"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="-468.58493"
+       y="279.12677"
        id="text3761"
        transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan3763"
-         x="-468.68051"
-         y="279.15356"
-         style="font-size:16.90952492px;line-height:1.25;font-family:sans-serif">Set #0</tspan></text>
+         x="-468.58493"
+         y="279.12677"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.90952492px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Set #0</tspan></text>
     <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 173.19592,324.76982 0,53.88646 201.31142,0 0,-53.88646 -148.6453,0 0,8.18205 -31.01841,0 0,-8.18205 -21.64771,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 173.19592,324.76982 v 53.88646 h 201.31142 v -53.88646 h -148.6453 v 8.18205 h -31.01841 v -8.18205 z"
        id="rect2985-9"
        inkscape:connector-curvature="0" />
     <rect
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect3759-4"
        width="31.03067"
-       height="92.811218"
+       height="97.986473"
        x="194.83586"
-       y="239.8582" />
+       y="234.68297" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="-326.74109"
-       y="216.42601"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="-326.55276"
+       y="214.74371"
        id="text3761-8"
        transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan3763-8"
-         x="-326.74109"
-         y="216.42601"
-         style="font-size:16.90952492px;line-height:1.25;font-family:sans-serif">Binding #0</tspan></text>
+         x="-326.55276"
+         y="214.74371"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16.90952492px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Binding #0</tspan></text>
     <path
-       style="fill:none;stroke:#ffff00;stroke-width:3.94555569;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:none"
-       d="m 272.88537,384.46437 0,21.33821"
+       style="fill:none;stroke:#ffff00;stroke-width:3.94555569;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none"
+       d="m 273.07881,384.46437 v 21.33821"
        id="path3853"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="203.9006"
-       y="360.43683"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="199.33853"
+       y="358.57181"
        id="text2987-2"><tspan
          sodipodi:role="line"
          id="tspan2989-4"
-         x="203.9006"
-         y="360.43683"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">Descriptor set</tspan></text>
+         x="199.33853"
+         y="358.57181"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Descriptor set</tspan></text>
     <path
-       style="fill:none;stroke:#ffff00;stroke-width:3.94555569;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:none"
-       d="m 210.07856,213.35608 0,21.33821"
+       style="fill:none;stroke:#ffff00;stroke-width:3.94555569;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none"
+       d="m 210.3512,208.01911 v 21.33821"
        id="path3853-5"
        inkscape:connector-curvature="0" />
     <path
-       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 190.81392,207.69429 38.52927,0 0,-87.71793 -38.52927,0 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.69095254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 191.08656,202.51905 h 38.52927 v -82.54269 h -38.52927 z"
        id="rect2985-9-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-       x="-193.51254"
-       y="218.39975"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       x="-194.97868"
+       y="218.8665"
        id="text2987-2-1"
        transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan2989-4-7"
-         x="-193.51254"
-         y="218.39975"
-         style="font-size:22.54603386px;line-height:1.25;font-family:sans-serif">Buffer</tspan></text>
+         x="-194.97868"
+         y="218.8665"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:22.54603386px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Buffer</tspan></text>
   </g>
 </svg>

--- a/static/guide-descriptor-sets-1.svg
+++ b/static/guide-descriptor-sets-1.svg
@@ -17,6 +17,7 @@
    sodipodi:docname="guide-descriptor-sets-1.svg">
   <defs
      id="defs4">
+    <style type="text/css">@import 'svg-styles.css';</style>
     <marker
        inkscape:stockid="Arrow1Mstart"
        orient="auto"

--- a/static/guide-fragment-shader-1.svg
+++ b/static/guide-fragment-shader-1.svg
@@ -16,7 +16,9 @@
    inkscape:version="0.48.5 r10040"
    sodipodi:docname="guide-vertex-input-2.svg">
   <defs
-     id="defs3283" />
+      id="defs3283">
+    <style type="text/css">@import 'svg-styles.css';</style>
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"

--- a/static/guide-fragment-shader-1.svg
+++ b/static/guide-fragment-shader-1.svg
@@ -13,11 +13,13 @@
    height="369.50262"
    id="svg3281"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="guide-vertex-input-2.svg">
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="guide-fragment-shader-1.svg">
   <defs
-      id="defs3283">
-    <style type="text/css">@import 'svg-styles.css';</style>
+     id="defs3283">
+    <style
+       type="text/css"
+       id="style2">@import 'svg-styles.css';</style>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -26,9 +28,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.979899"
-     inkscape:cx="161.5352"
-     inkscape:cy="216.36113"
+     inkscape:zoom="5.6"
+     inkscape:cx="159.50979"
+     inkscape:cy="130.64684"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -36,10 +38,10 @@
      fit-margin-top="10"
      fit-margin-right="10"
      fit-margin-bottom="10"
-     inkscape:window-width="1680"
-     inkscape:window-height="987"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:window-width="3840"
+     inkscape:window-height="2031"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata3286">
@@ -49,7 +51,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -178,12 +180,6 @@
        style="fill:#646464;fill-opacity:1;stroke:#646464;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 189.09685,539.71418 313.65238,0"
        id="path4792-7-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:#646464;fill-opacity:1;stroke:#646464;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 189.09685,552.96556 313.65238,0"
-       id="path4792-1-80"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
@@ -840,5 +836,11 @@
        id="path5672"
        inkscape:connector-curvature="0"
        transform="translate(90.354446,277.19701)" />
+    <path
+       style="fill:#646464;fill-opacity:1;stroke:#646464;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 189.09685,552.96556 313.65238,0"
+       id="path4792-1-80"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
   </g>
 </svg>

--- a/static/guide-vertex-input-1.svg
+++ b/static/guide-vertex-input-1.svg
@@ -16,7 +16,9 @@
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="guide-vertex-input-1.svg">
   <defs
-     id="defs3283" />
+      id="defs3283">
+    <style type="text/css">@import 'svg-styles.css';</style>
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"

--- a/static/guide-vertex-input-1.svg
+++ b/static/guide-vertex-input-1.svg
@@ -16,8 +16,10 @@
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="guide-vertex-input-1.svg">
   <defs
-      id="defs3283">
-    <style type="text/css">@import 'svg-styles.css';</style>
+     id="defs3283">
+    <style
+       type="text/css"
+       id="style236">@import 'svg-styles.css';</style>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -26,9 +28,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="63.356767"
-     inkscape:cx="457.75564"
-     inkscape:cy="180.09078"
+     inkscape:zoom="5.0469314"
+     inkscape:cx="243.3691"
+     inkscape:cy="184.73832"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -40,7 +42,15 @@
      inkscape:window-height="2031"
      inkscape:window-x="0"
      inkscape:window-y="55"
-     inkscape:window-maximized="1" />
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       position="198.93276,322.37411"
+       orientation="0,1"
+       id="guide288"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
   <metadata
      id="metadata3286">
     <rdf:RDF>
@@ -67,15 +77,15 @@
        y="303.83914" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#646464;fill-opacity:1;stroke:none"
-       x="233.73067"
-       y="536.638"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#646464;fill-opacity:1;stroke:none"
+       x="238.08975"
+       y="537.62872"
        id="text4061"><tspan
          sodipodi:role="line"
-         x="233.73067"
-         y="536.638"
+         x="238.08975"
+         y="537.62872"
          id="tspan4163"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">Target image</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Target image</tspan></text>
     <path
        style="fill:none;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 128.28937,465.38233 428.30468,0"
@@ -88,67 +98,67 @@
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#b90000;fill-opacity:1;stroke:none"
-       x="384.41611"
-       y="521.10315"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#b90000;fill-opacity:1;stroke:none"
+       x="385.01053"
+       y="482.66397"
        id="text4069"><tspan
          sodipodi:role="line"
          id="tspan4071"
-         x="384.41611"
-         y="521.10315"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">Coordinates</tspan><tspan
+         x="385.01053"
+         y="482.66397"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">Coordinate</tspan><tspan
          sodipodi:role="line"
-         x="384.41611"
-         y="538.60315"
+         x="385.01053"
+         y="500.16397"
          id="tspan4073"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">system</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">system</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="193.94928"
-       y="324.04218"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="194.31534"
+       y="321.01892"
        id="text4075"><tspan
          sodipodi:role="line"
          id="tspan4077"
-         x="193.94928"
-         y="324.04218"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(-1, -1)</tspan></text>
+         x="194.31534"
+         y="321.01892"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(-1, -1)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
        x="352.19006"
-       y="323.62463"
+       y="321.17615"
        id="text4075-1"><tspan
          sodipodi:role="line"
          id="tspan4077-7"
          x="352.19006"
-         y="323.62463"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(0, -1)</tspan></text>
+         y="321.17615"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(0, -1)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="460.57224"
-       y="321.35922"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="459.70282"
+       y="321.01892"
        id="text4075-4"><tspan
          sodipodi:role="line"
          id="tspan4077-0"
-         x="460.57224"
-         y="321.35922"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(1, -1)</tspan></text>
+         x="459.70282"
+         y="321.01892"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(1, -1)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="462.27637"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="464.21454"
        y="459.914"
        id="text4075-9"><tspan
          sodipodi:role="line"
          id="tspan4077-4"
-         x="462.27637"
+         x="464.21454"
          y="459.914"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(1, 0)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(1, 0)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none;-inkscape-font-specification:'Open Sans';font-stretch:normal;font-variant:normal;"
        x="349.22049"
        y="457.97495"
        id="text4075-8"><tspan
@@ -156,51 +166,51 @@
          id="tspan4077-8"
          x="349.22049"
          y="457.97495"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(0, 0)</tspan></text>
+         style="font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">(0, 0)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="192.62657"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="194.31534"
        y="457.95462"
        id="text4075-2"><tspan
          sodipodi:role="line"
          id="tspan4077-45"
-         x="192.62657"
+         x="194.31534"
          y="457.95462"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(-1, 0)</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(-1, 0)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="193.59612"
-       y="607.47754"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="194.31534"
+       y="608.59607"
        id="text4075-5"><tspan
          sodipodi:role="line"
          id="tspan4077-1"
-         x="193.59612"
-         y="607.47754"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(-1, 1)</tspan></text>
+         x="194.31534"
+         y="608.59607"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(-1, 1)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
        x="349.15961"
-       y="606.48767"
+       y="608.59607"
        id="text4075-7"><tspan
          sodipodi:role="line"
          id="tspan4077-11"
          x="349.15961"
-         y="606.48767"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(0, 1)</tspan></text>
+         y="608.59607"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(0, 1)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="464.27637"
-       y="609.45721"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="464.21454"
+       y="608.59607"
        id="text4075-52"><tspan
          sodipodi:role="line"
          id="tspan4077-76"
-         x="464.27637"
-         y="609.45721"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(1, 1)</tspan></text>
+         x="464.21454"
+         y="608.59607"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(1, 1)</tspan></text>
     <path
        style="fill:none;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 344.31311,635.8405 -5.03498,-5.03498"

--- a/static/guide-vertex-input-2.svg
+++ b/static/guide-vertex-input-2.svg
@@ -16,7 +16,9 @@
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="guide-vertex-input-2.svg">
   <defs
-     id="defs3283" />
+      id="defs3283">
+    <style type="text/css">@import 'svg-styles.css';</style>
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"

--- a/static/guide-vertex-input-2.svg
+++ b/static/guide-vertex-input-2.svg
@@ -16,8 +16,10 @@
    inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="guide-vertex-input-2.svg">
   <defs
-      id="defs3283">
-    <style type="text/css">@import 'svg-styles.css';</style>
+     id="defs3283">
+    <style
+       type="text/css"
+       id="style273">@import 'svg-styles.css';</style>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -26,9 +28,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.979899"
-     inkscape:cx="190.82962"
-     inkscape:cy="223.93727"
+     inkscape:zoom="5.5287093"
+     inkscape:cx="248.73423"
+     inkscape:cy="185.78177"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -40,7 +42,16 @@
      inkscape:window-height="2031"
      inkscape:window-x="0"
      inkscape:window-y="55"
-     inkscape:window-maximized="1" />
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-object-midpoints="false"
+     inkscape:snap-others="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-grids="false"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-to-guides="true" />
   <metadata
      id="metadata3286">
     <rdf:RDF>
@@ -67,29 +78,29 @@
        y="303.83914" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="228.94928"
-       y="361.89932"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="224.41011"
+       y="364.2048"
        id="text4075"><tspan
          sodipodi:role="line"
          id="tspan4077"
-         x="228.94928"
-         y="361.89932"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(-0.5, -0.5)</tspan></text>
+         x="224.41011"
+         y="364.2048"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(-0.5, -0.5)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
-       x="320.04721"
-       y="569.33893"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       x="318.35849"
+       y="564.53076"
        id="text4075-1"><tspan
          sodipodi:role="line"
          id="tspan4077-7"
-         x="320.04721"
-         y="569.33893"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(0, 0.5)</tspan></text>
+         x="318.35849"
+         y="564.53076"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans'">(0, 0.5)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:'Open Sans';letter-spacing:0px;word-spacing:0px;fill:#b90000;fill-opacity:1;stroke:none;-inkscape-font-specification:'Open Sans';font-stretch:normal;font-variant:normal;"
        x="426.28653"
        y="428.35922"
        id="text4075-4"><tspan
@@ -97,7 +108,7 @@
          id="tspan4077-0"
          x="426.28653"
          y="428.35922"
-         style="font-size:14px;line-height:1.25;font-family:sans-serif">(0.5, -0.25)</tspan></text>
+         style="font-size:14px;line-height:1.25;font-family:'Open Sans';-inkscape-font-specification:'Open Sans';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">(0.5, -0.25)</tspan></text>
     <path
        style="fill:#b90000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
        d="M 166,91.359767 249.57143,274.50262 344.71429,159.64548 z"

--- a/static/svg-styles.css
+++ b/static/svg-styles.css
@@ -1,0 +1,22 @@
+/* The SVG diagrams in this directory import this style sheet via nodes like:
+
+   <style type="text/css">@import 'svg-styles.css';</style>
+
+   (If the other tags in the SVG are namespaced, the starting and ending tags
+   must be 'svg:style'.)
+
+   You can edit this into the SVG manually, or use Inkscape's XML editor. It
+   should a child of the 'defs' node. Once you've added it, Inkscape should
+   leave it there. */
+
+/* Definitions for fonts loaded from Google Fonts. For editing with Inkscape,
+   you should install these fonts locally. */
+
+/* Open Sans: https://fonts.google.com/specimen/Open+Sans
+   Available under the Apache License, Version 2.0. */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v15/mem8YaGs126MiZpBA-UFVZ0e.ttf) format('truetype');
+}


### PR DESCRIPTION
When I read the Vulkano guide, diagrams often include text that is poorly aligned in the diagram, or clipped outside the drawing altogether. Here's a screen shot:

![image](https://user-images.githubusercontent.com/751272/42456124-dff00c7c-8348-11e8-912d-334618a2cdea.png)

I think this is because the images are SVG documents that end up using fallback fonts different from those used to draw the diagram. Given the nature of SVG diagrams, pretty much any sort of font fallback is unacceptable; even in the best case, labels don't land where they should and things look sloppy. In the worst case, you get clipping that obscures necessary content.

This pull request changes the Vulkano guide's SVG diagrams to use the font Open Sans, and fetch it from fonts.google.com, the web fonts server. Open Sans is available under the Apache License Version 2.0. Inkscape doesn't fetch web fonts, as far as I can tell, but Open Sans is downloadable from that site and packaged for many Linux distributions, so you can install it locally for editing.

The request is in three commits:

-   First, we use `<object>` elements for SVG diagrams instead of `<img>` elements, since Firefox will not fetch any external resources for SVGs loaded as `<img>` elements.

-   Next, we add a `<style>` element to each SVG that imports a new style sheet in the `static` directory. This way, we can add more fonts, etc. without needing to edit every SVG file again. No other changes are made to the diagram.

-   Finally, we change the text elements in the SVGs to use Open Sans, and tweak the diagrams as needed for alignment, etc.

Each change's commit message has more details.

View-tested in Firefox and Chrome.

[edited, to bring image down to a reasonable size and fix element names]