### PR TITLE
Update guide to vulkano 0.10.0 and improve it a bit

### DIFF
--- a/content/guide-acquire-present.md
+++ b/content/guide-acquire-present.md
@@ -1,4 +1,4 @@
-# Usage a swapchain
+# Usage of a swapchain
 
 In order to use the swapchain, we have to start by *acquiring* an image. This is done with the
 `swapchain::acquire_next_image()` function.
@@ -14,7 +14,7 @@ of the tuple is a *future* that represents the moment when the image will be acq
 The `acquire_next_image` function will block until an image is available. This can happen depending
 on the present mode.
 
-*To be finished*
+*To be finished* - check the [Triangle example](https://github.com/vulkano-rs/vulkano-examples/blob/master/triangle/main.rs) for now.
 
 ## Clearing the image
 

--- a/content/guide-buffer-creation.md
+++ b/content/guide-buffer-creation.md
@@ -116,3 +116,5 @@ content[7] = 3;
 Just like the constructors, keep in mind that being able to read/write the content of the buffer
 like this is specific to the `CpuAccessibleBuffer`. Other kinds of buffers (for example the
 `ImmutableBuffer`) do not provide such methods.
+
+Next: [Example operation](/guide/example-operation)

--- a/content/guide-compute-pipeline.md
+++ b/content/guide-compute-pipeline.md
@@ -121,7 +121,7 @@ macros are stabilized.
 To use `vulkano-shader-derive`, we first have to add a dependency:
 
 ```toml
-vulkano-shader-derive = "0.7"
+vulkano-shader-derive = "0.10.0"
 ```
 
 And add these lines to our crate root:

--- a/content/guide-device-creation.md
+++ b/content/guide-device-creation.md
@@ -73,3 +73,5 @@ let queue = queues.next().unwrap();
 
 We now have our `device` and our `queue`, which means that we are ready to ask the GPU to perform
 operations.
+
+Next: [Creating a buffer](/guide/buffer-creation)

--- a/content/guide-dispatch.md
+++ b/content/guide-dispatch.md
@@ -42,3 +42,5 @@ for (n, val) in content.iter().enumerate() {
 
 println!("Everything succeeded!");
 ```
+
+Next: [Creating an image](/guide/image-creation)

--- a/content/guide-example-operation.md
+++ b/content/guide-example-operation.md
@@ -105,3 +105,5 @@ let src_content = source.read().unwrap();
 let dest_content = dest.read().unwrap();
 assert_eq!(&*src_content, &*dest_content);
 ```
+
+Next: [Introduction to compute operations](/guide/compute-intro)

--- a/content/guide-fragment-shader.md
+++ b/content/guide-fragment-shader.md
@@ -38,3 +38,5 @@ The `main()` function is executed once for each pixel covered by the triangle an
 section](/guide/image-clear) these values are normalized, in other words the value `1.0` will in
 reality write `255` in memory. In this example since our target image contains colors, we write the
 color red.
+
+Next: [Render passes and framebuffers](render-pass-framebuffer)

--- a/content/guide-graphics-pipeline-creation.md
+++ b/content/guide-graphics-pipeline-creation.md
@@ -136,7 +136,7 @@ example](/guide/mandelbrot) and write the image to a PNG file.
 
     .build()
     .unwrap();
-    
+
 let finished = command_buffer.execute(queue.clone()).unwrap();
 finished.then_signal_fence_and_flush().unwrap()
     .wait(None).unwrap();
@@ -154,3 +154,5 @@ And here is what you should get:
 
 > **Note**: You can find the [full source code of this section
 > here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/guide-triangle.rs).
+
+Next: [Windowing](/guide/window)

--- a/content/guide-image-clear.md
+++ b/content/guide-image-clear.md
@@ -40,3 +40,5 @@ With any format whose suffix is `Unorm` (but also `Snorm` and `Srgb`), all the o
 performed on the image (with the exception of memory copies) treat the image as if it contained
 floating-point values. This is the reason why we pass `[0.0, 0.0, 1.0, 1.0]`. The values `1.0` will
 in fact be stored as `255` in memory.
+
+Next: [Exporting the result](/guide/image-export)

--- a/content/guide-image-creation.md
+++ b/content/guide-image-creation.md
@@ -77,3 +77,5 @@ access the image.
 
 > **Note**: Images also have usage flags similar to buffers, but this precise constructor doesn't
 > require them.
+
+Next: [Clearing an image](/guide/image-clear)

--- a/content/guide-image-export.md
+++ b/content/guide-image-export.md
@@ -86,3 +86,5 @@ And that's it! When running your program, a blue image named `image.png` should 
 This might look stupid, but think about the fact that it's the GPU that wrote the content of
 the image. In the next sections we will do more than just fill an image with blue, but we will
 continue to retreive the image's content and write it to a PNG file.
+
+Next: [Drawing a fractal with a compute shader](/guide/mandelbrot)

--- a/content/guide-image-export.md
+++ b/content/guide-image-export.md
@@ -50,7 +50,7 @@ file. The Rust ecosystem has a crate named `image` that can do this.
 Let's add it to our Cargo.toml:
 
 ```toml
-image = "0.14"
+image = "0.19.0"
 ```
 
 And to our crate root:

--- a/content/guide-initialization.md
+++ b/content/guide-initialization.md
@@ -59,3 +59,5 @@ necessarily the best device. In a real program you probably want to leave the ch
 Keep in mind that the list of physical devices can be empty. This happens if Vulkan is installed
 on the system, but none of the physical devices of the machine are capable of supporting Vulkan. In
 a real-world application you are encouraged to handle this situation properly as well.
+
+Next: [Initialization](/guide/device-creation)

--- a/content/guide-mandelbrot.md
+++ b/content/guide-mandelbrot.md
@@ -178,3 +178,5 @@ And here is what you should get:
 <center>
 ![](/guide-mandelbrot-1.png)
 </center>
+
+Next: [Graphics pipeline introduction](/guide/what-graphics-pipeline)

--- a/content/guide-swapchain-creation.md
+++ b/content/guide-swapchain-creation.md
@@ -22,12 +22,12 @@ parameters when we create the swapchain. Therefore before we can do so we have t
 capabilities of the surface.
 
 ```rust
-let caps = window.surface().capabilities(physical)
+let caps = surface.capabilities(physical)
     .expect("failed to get surface capabilities");
 ```
 
 If we don't really care about all these properties, the only things that we need to choose is
-the dimensions of the image (which have to be constrainted between a minimum and a maximum), the
+the dimensions of the image (which have to be constrained between a minimum and a maximum), the
 behavior when it comes to transparency, and the format of the images.
 
 ```rust
@@ -39,8 +39,26 @@ let format = caps.supported_formats[0].0;
 We can now create the swapchain:
 
 ```rust
-let (swapchain, images) = Swapchain::new(device.clone(), window.surface().clone(),
+use vulkano::swapchain::{Swapchain, SurfaceTransform, PresentMode};
+
+let (swapchain, images) = Swapchain::new(device.clone(), surface.clone(),
     caps.min_image_count, format, dimensions, 1, caps.supported_usage_flags, &queue,
     SurfaceTransform::Identity, alpha, PresentMode::Fifo, true, None)
     .expect("failed to create swapchain");
 ```
+
+In addition to this, we also need to adapt our device creation code to enable the required extension:
+
+```rust
+let (device, mut queues) = {
+    let device_ext = vulkano::device::DeviceExtensions {
+        khr_swapchain: true,
+        .. vulkano::device::DeviceExtensions::none()
+    };
+
+    Device::new(physical, physical.supported_features(), &device_ext,
+                [(queue, 0.5)].iter().cloned()).expect("failed to create device")
+};
+```
+
+Next: [Acquiring and presenting](/guide/acquire-present)

--- a/content/guide-what-graphics-pipeline.md
+++ b/content/guide-what-graphics-pipeline.md
@@ -52,3 +52,5 @@ options that allows one to further configure the behavior of the graphics card.
 > have tons of configurable options, plus additional optional shader stages.
 
 The next sections will be dedicated to covering graphics pipeline in more details.
+
+Next: [Vertex input](/guide/vertex-input)

--- a/content/guide-window.md
+++ b/content/guide-window.md
@@ -15,8 +15,8 @@ going to add a dependency to the `vulkano-win` crate which is a link between vul
 In your Cargo.toml:
 
 ```toml
-vulkano-win = "0.7"
-winit = "0.7"
+vulkano-win = "0.10.0"
+winit = "0.17.1"
 ```
 
 And at the crate root:
@@ -72,7 +72,7 @@ window's events. This is typically done after initialization, and right before t
 ```rust
 events_loop.run_forever(|event| {
     match event {
-        winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => {
+        winit::Event::WindowEvent { event: winit::WindowEvent::CloseRequested, .. } => {
             winit::ControlFlow::Break
         },
         _ => winit::ControlFlow::Continue,

--- a/content/guide-window.md
+++ b/content/guide-window.md
@@ -35,13 +35,12 @@ use winit::EventsLoop;
 use winit::WindowBuilder;
 
 let mut events_loop = EventsLoop::new();
-let window = WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
+let surface = WindowBuilder::new().build_vk_surface(&events_loop, instance.clone()).unwrap();
 ```
 
 This code creates a window with the default parameters, and also builds a Vulkan *surface* object
 that represents the surface of that window whenever the Vulkan API is concerned.
-Calling `window.window()` will return an object that allows you to manipulate the window, and
-calling `window.surface()` will return a `Surface` object of `vulkano`.
+Calling `surface.window()` will return an object that allows you to manipulate the window.
 
 However, if you try to run this code you will notice that the `build_vk_surface` returns an error.
 The reason is that surfaces are actually not part of Vulkan itself, but of one of several
@@ -90,5 +89,5 @@ return `ControlFlow::Break`. This stops the `run_forever` function.
 ## Conclusion
 
 Right now, all we're doing is creating a window and keeping our program alive for as long as the
-window isn't closed. The next section will show how to initialize what is called a *swapchain* on
+window isn't closed. The [next section](/guide/swapchain-creation) will show how to initialize what is called a *swapchain* on
 the window's surface.

--- a/content/template_guide.html
+++ b/content/template_guide.html
@@ -54,7 +54,7 @@
         <!--
 
             The sections below are work in progress
-        
+
         <h3>About futures</h3>
 
         <ul>
@@ -66,18 +66,15 @@
 
         <ul>
             <li><a href="/guide/window">Window creation</a></li>
-        <!--
 
-            The sections below are work in progress
-        
             <li><a href="/guide/swapchain-creation">Swapchain creation</a></li>
-            <li><a href="/guide/acquire-present">Acquiring and presenting</a></li>-->
+            <li><a href="/guide/acquire-present">Acquiring and presenting</a></li>
         </ul>
 
         <!--
 
             The sections below are work in progress
-        
+
         <h3>Misc</h3>
 
         <ul>

--- a/content/template_main.html
+++ b/content/template_main.html
@@ -8,7 +8,7 @@
     </head>
     <body>
         <script src="/prism.js"></script>
-        <a href="https://github.com/vulkano-rs/vulkano-www"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
+        <a href="https://github.com/vulkano-rs/vulkano"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
 
         <header>
             <h1>Vulkano</h1>


### PR DESCRIPTION
Updates the guide for 0.10.0 + a few small changes:
- link every page to the next (I accidentally skipped a section while reading through...)
- finish swapchain creation page (I hope)
- show unfinished "window" pages and link to the triangle example where stuff is missing (less confusing than just ending on the window creation page I think)
- link to the "fork me on github" button to vulkano instead of vulkano-www (#18)

~`resolves #32`~
resolves #18 