### PR TITLE
Use ref in pipeline tutorial code

### DIFF
--- a/content/guide-graphics-pipeline-creation.md
+++ b/content/guide-graphics-pipeline-creation.md
@@ -116,7 +116,7 @@ let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.cl
     .begin_render_pass(framebuffer.clone(), false, vec![[0.0, 0.0, 1.0, 1.0].into()])
     .unwrap()
 
-    .draw(pipeline.clone(), dynamic_state, vertex_buffer.clone(), (), ())
+    .draw(pipeline.clone(), &dynamic_state, vertex_buffer.clone(), (), ())
     .unwrap()
 
     .end_render_pass()


### PR DESCRIPTION
This fixes a compilation error for readers following along with the tutorial. `draw` expects a reference to the `DynamicState`, not the `DynamicState` struct itself. 