### PR TITLE
Fix failed type inference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ fn main_template<S>(body: S) -> Response
         Entry::Occupied(e) => e.into_mut(),
         Entry::Vacant(e) => {
             let data = mustache::MapBuilder::new()
-                .insert_str("body", e.key().as_ref())
+                .insert_str("body", e.key().as_str())
                 .build();
 
             let mut out = Vec::new();
@@ -182,7 +182,7 @@ fn guide_template<S>(body: S) -> Response
         Entry::Occupied(e) => e.into_mut(),
         Entry::Vacant(e) => {
             let data = mustache::MapBuilder::new()
-                .insert_str("body", e.key().as_ref())
+                .insert_str("body", e.key().as_str())
                 .build();
 
             let mut out = Vec::new();


### PR DESCRIPTION
The use of `as_ref()` delegate at the compiler the inference of the type, but when casting a `String` to a `&str` this is counter-productive like in this case.
It better uses `as_str()` that specify the type without a doubt.

Without this fix is guaranteed the code will not compile on Rust 1.39+ (see https://github.com/vulkano-rs/vulkano-www/issues/71 )