### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.6 AS builder
+FROM alpine:3.10 AS builder
 RUN apk add --no-cache cargo rust
 COPY . /root/
 RUN cargo build --release --manifest-path=/root/Cargo.toml
 
-FROM alpine:3.6
+FROM alpine:3.10
 RUN apk add --no-cache curl llvm-libunwind
 WORKDIR /root
 COPY ./static /root/static


### PR DESCRIPTION
With the 3.10 version of Alpine Docker will build the container successfully.

Fix https://github.com/vulkano-rs/vulkano-www/issues/72 and has been tested with applied https://github.com/vulkano-rs/vulkano-www/pull/73 and https://github.com/vulkano-rs/vulkano-www/pull/74 .