### PR TITLE
Fix #78 #79 #80; Update swapchain creation example to use ImageUsage::color_attachment()

### DIFF
--- a/content/guide-descriptor-sets.md
+++ b/content/guide-descriptor-sets.md
@@ -32,8 +32,9 @@ all represent a descriptor set. Here we are going to use a `PersistentDescriptor
 
 ```rust
 use vulkano::descriptor::descriptor_set::PersistentDescriptorSet;
+use vulkano::descriptor::PipelineLayoutAbstract;
 
-let layout = pipeline.layout().descriptor_set_layout(0).unwrap();
+let layout = compute_pipeline.layout().descriptor_set_layout(0).unwrap();
 let set = Arc::new(PersistentDescriptorSet::start(layout.clone())
     .add_buffer(data_buffer.clone()).unwrap()
     .build().unwrap()

--- a/content/guide-graphics-pipeline-creation.md
+++ b/content/guide-graphics-pipeline-creation.md
@@ -116,7 +116,7 @@ let command_buffer = AutoCommandBufferBuilder::primary_one_time_submit(device.cl
     .begin_render_pass(framebuffer.clone(), false, vec![[0.0, 0.0, 1.0, 1.0].into()])
     .unwrap()
 
-    .draw(pipeline.clone(), dynamic_state, vertex_buffer.clone(), (), ())
+    .draw(pipeline.clone(), &dynamic_state, vertex_buffer.clone(), (), ())
     .unwrap()
 
     .end_render_pass()
@@ -150,7 +150,7 @@ image.save("triangle.png").unwrap();
 And here is what you should get:
 
 <center>
-![](/guide-graphics-pipeline-creation-1.png)
+<img src="/guide-graphics-pipeline-creation-1.png" />
 </center>
 
 Next: [Windowing](/guide/window)

--- a/content/guide-image-export.md
+++ b/content/guide-image-export.md
@@ -77,7 +77,7 @@ image.save("image.png").unwrap();
 And that's it! When running your program, a blue image named `image.png` should appear.
 
 <center>
-![](/guide-image-export-1.png)
+<img src="/guide-image-export-1.png" />
 
 *Here it is.*
 </center>

--- a/content/guide-introduction.md
+++ b/content/guide-introduction.md
@@ -36,7 +36,7 @@ You will first need to setup some external dependencies as documented in the [Vu
 As with all Rust libraries, add this entry in your Cargo.toml:
 
 ```toml
-vulkano = "0.18"
+vulkano = "0.19"
 ```
 
 Note: If you run into any issues with this guide, please [open an issue](https://github.com/vulkano-rs/vulkano-www/issues).

--- a/content/guide-mandelbrot.md
+++ b/content/guide-mandelbrot.md
@@ -177,7 +177,7 @@ image.save("image.png").unwrap();
 And here is what you should get:
 
 <center>
-![](/guide-mandelbrot-1.png)
+<img src="/guide-mandelbrot-1.png" />
 </center>
 
 Next: [Graphics pipeline introduction](/guide/what-graphics-pipeline)

--- a/content/guide-swapchain-creation.md
+++ b/content/guide-swapchain-creation.md
@@ -40,9 +40,10 @@ We can now create the swapchain:
 
 ```rust
 use vulkano::swapchain::{Swapchain, SurfaceTransform, PresentMode, ColorSpace, FullscreenExclusive};
+use vulkano::image::ImageUsage;
 
 let (swapchain, images) = Swapchain::new(device.clone(), surface.clone(),
-    caps.min_image_count, format, dimensions, 1, caps.supported_usage_flags, &queue,
+    caps.min_image_count, format, dimensions, 1, ImageUsage::color_attachment(), &queue,
     SurfaceTransform::Identity, alpha, PresentMode::Fifo, FullscreenExclusive::Default,
 	true, ColorSpace::SrgbNonLinear)
     .expect("failed to create swapchain");

--- a/content/guide-window.md
+++ b/content/guide-window.md
@@ -15,7 +15,7 @@ going to add a dependency to the `vulkano-win` crate which is a link between vul
 In your Cargo.toml:
 
 ```toml
-vulkano-win = "0.18"
+vulkano-win = "0.19"
 winit = "0.22"
 ```
 

--- a/examples/guide-compute-operations.rs
+++ b/examples/guide-compute-operations.rs
@@ -25,7 +25,7 @@ use vulkano::instance::InstanceExtensions;
 use vulkano::instance::PhysicalDevice;
 use vulkano::pipeline::ComputePipeline;
 use vulkano::sync::GpuFuture;
-use vulkano::descriptor::pipeline_layout::PipelineLayoutAbstract;
+use vulkano::descriptor::PipelineLayoutAbstract;
 
 fn main() {
     let instance = Instance::new(None, &InstanceExtensions::none(), None)
@@ -38,7 +38,7 @@ fn main() {
         .expect("couldn't find a compute queue family");
 
     let (device, mut queues) = {
-        Device::new(physical, &Features::none(), 
+        Device::new(physical, &Features::none(),
             &DeviceExtensions{khr_storage_buffer_storage_class:true, ..DeviceExtensions::none()},
                     [(queue_family, 0.5)].iter().cloned()).expect("failed to create device")
     };


### PR DESCRIPTION
Fixes: https://github.com/vulkano-rs/vulkano-www/issues/80, https://github.com/vulkano-rs/vulkano-www/issues/79, https://github.com/vulkano-rs/vulkano-www/issues/78

Update swapchain example to use new `ImageUsage::color_attachment()` constructor (https://github.com/vulkano-rs/vulkano/pull/1372) instead of using the supported usage from the swapchain caps. This resolves possible issues with unsupported usages on the swapchain image by limiting the usage to only what is needed. (See https://github.com/vulkano-rs/vulkano/issues/1318, https://github.com/vulkano-rs/vulkano/issues/1341)