### PR TITLE
Update link to triangle examples

### DIFF
--- a/content/home.html
+++ b/content/home.html
@@ -34,6 +34,6 @@
 
     <div id="jump">
         <a href="/guide/introduction"><i class="fas fa-book-reader"></i> Guide</a>
-        <a href="https://github.com/vulkano-rs/vulkano-examples/blob/master/src/bin/triangle.rs"><i class="fas fa-laptop"></i> Triangle example</a>
+        <a href="https://github.com/vulkano-rs/vulkano/blob/master/examples/src/bin/triangle.rs"><i class="fas fa-laptop"></i> Triangle example</a>
     </div>
 </div>


### PR DESCRIPTION
The vulkano-examples repository is archived, the examples are now maintained in the main vulkano repository, so it seems wrong to link to vulkano-examples from the home page of the project.