### PR TITLE
Fix links and add target blank to external links

### DIFF
--- a/content/donate.html
+++ b/content/donate.html
@@ -3,17 +3,17 @@
 	
 	<p>
 		Austin Johnson (active maintainer)
-		<a href="https://www.patreon.com/bePatron?u=163288" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+		<a target="_blank" href="https://www.patreon.com/bePatron?u=163288" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
 	</p>
 	
     <p>
         Rukai (current maintainer)
-        <a href="https://www.patreon.com/bePatron?u=6776200" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+        <a target="_blank" href="https://www.patreon.com/bePatron?u=6776200" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
     </p>
 
     <p>
         Tomaka (original developer)
-        <a href="https://www.patreon.com/bePatron?u=6293946" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
+        <a target="_blank" href="https://www.patreon.com/bePatron?u=6293946" data-patreon-widget-type="become-patron-button">Become a Patron!</a><script async src="https://c6.patreon.com/becomePatronButton.bundle.js"></script>
     </p>
 
     <h2>Thank you very much!</h2>

--- a/content/guide/buffer_creation/example_operation.md
+++ b/content/guide/buffer_creation/example_operation.md
@@ -6,6 +6,9 @@ to actually do something.
 What we are going to ask in this example is very simple: we will ask it to copy data from one
 buffer to another.
 
+> **Note**: You can find the [full source code of this section
+> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/buffer_creation.rs).
+
 ## Creating the buffers
 
 The first step is to create two `CpuAccessibleBuffer`s: the source and the destination. This

--- a/content/guide/buffer_creation/example_operation.md
+++ b/content/guide/buffer_creation/example_operation.md
@@ -6,9 +6,6 @@ to actually do something.
 What we are going to ask in this example is very simple: we will ask it to copy data from one
 buffer to another.
 
-> **Note**: You can find the [full source code of this section
-> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/guide-example-operation.rs).
-
 ## Creating the buffers
 
 The first step is to create two `CpuAccessibleBuffer`s: the source and the destination. This

--- a/content/guide/compute_pipeline/compute_intro.md
+++ b/content/guide/compute_pipeline/compute_intro.md
@@ -21,7 +21,7 @@ by one, a GPU can perform it on multiple values at once.
 > are usually foremost *software* queues, and not actual hardware constructs.
 
 > **Note**: You can find the [full source code of this section
-> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/guide-compute-operations.rs).
+> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/compute_pipeline.rs).
 
 ## Usability
 

--- a/content/guide/graphics_pipeline/pipeline_creation.md
+++ b/content/guide/graphics_pipeline/pipeline_creation.md
@@ -12,6 +12,9 @@ and a *framebuffer* that contains the target image.
 
 It is now time to put everything together and perform the draw operation!
 
+> **Note**: You can find the [full source code of this section
+> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/graphics_pipeline.rs).
+
 ## Creating a graphics pipeline
 
 Just like we had to create a compute pipeline in order to perform a compute operation, we have to

--- a/content/guide/graphics_pipeline/pipeline_creation.md
+++ b/content/guide/graphics_pipeline/pipeline_creation.md
@@ -12,9 +12,6 @@ and a *framebuffer* that contains the target image.
 
 It is now time to put everything together and perform the draw operation!
 
-> **Note**: You can find the [full source code of this section
-> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/guide-triangle.rs).
-
 ## Creating a graphics pipeline
 
 Just like we had to create a compute pipeline in order to perform a compute operation, we have to

--- a/content/guide/images/image_export.md
+++ b/content/guide/images/image_export.md
@@ -10,7 +10,7 @@ The answer to this question is that we have to create a buffer and ask the GPU t
 of the image to the buffer.
 
 > **Note**: You can find the [full source code of this section
-> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/guide-image-clear.rs).
+> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/images/image_clear.rs).
 >
 > **Note**: This time the device need a device extension for the use of storage buffers, see the line 36 of the full source code.
 

--- a/content/guide/images/mandelbrot.md
+++ b/content/guide/images/mandelbrot.md
@@ -10,7 +10,7 @@ as explained in that section. Each invocation of the `main` function of the shad
 one pixel.
 
 > **Note**: You can find the [full source code of this section
-> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/guide-mandelbrot.rs).
+> here](https://github.com/vulkano-rs/vulkano-www/blob/master/examples/images/mandelbrot.rs).
 
 # The shader
 

--- a/content/guide/windowing/acquire_present.md
+++ b/content/guide/windowing/acquire_present.md
@@ -14,7 +14,7 @@ of the tuple is a *future* that represents the moment when the image will be acq
 The `acquire_next_image` function will block until an image is available. This can happen depending
 on the present mode.
 
-*To be finished* - check the [Triangle example](https://github.com/vulkano-rs/vulkano-examples/blob/master/src/bin/triangle.rs) for now.
+*To be finished* - check the [Triangle example](https://github.com/vulkano-rs/vulkano/blob/master/examples/src/bin/triangle.rs) for now.
 
 ## Clearing the image
 

--- a/content/home.html
+++ b/content/home.html
@@ -34,6 +34,6 @@
 
     <div id="jump">
         <a href="/guide/introduction"><i class="fas fa-book-reader"></i> Guide</a>
-        <a href="https://github.com/vulkano-rs/vulkano/blob/master/examples/src/bin/triangle.rs"><i class="fas fa-laptop"></i> Triangle example</a>
+        <a target="_blank" href="https://github.com/vulkano-rs/vulkano/blob/master/examples/src/bin/triangle.rs"><i class="fas fa-laptop"></i> Triangle example</a>
     </div>
 </div>

--- a/content/template_main.html
+++ b/content/template_main.html
@@ -9,19 +9,19 @@
     </head>
     <body>
         <script src="/prism.js"></script>
-        <a href="https://github.com/vulkano-rs/vulkano"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
+        <a target="_blank" href="https://github.com/vulkano-rs/vulkano"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
 
         <header>
             <h1>Vulkano</h1>
-            <h2>Safe <a href="https://www.rust-lang.org/">Rust</a> wrapper around
-                the <a href="https://www.khronos.org/vulkan/">Vulkan</a> API</h2>
+            <h2>Safe <a target="_blank" href="https://www.rust-lang.org/">Rust</a> wrapper around
+                the <a target="_blank" href="https://www.khronos.org/vulkan/">Vulkan</a> API</h2>
 
             <ul>
                 <li><a href="/"><i class="fas fa-globe"></i>  Home</a></li>
                 <li><a href="/guide/introduction"><i class="fas fa-book"></i> Guide</a></li>
-                <li><a href="https://docs.rs/vulkano"><i class="fab fa-rust"></i> API</a></li>
-                <li><a href="https://discord.gg/bncB9W2VDV"><i class="fab fa-discord"></i> Discord</a></li>
-                <li><a href="https://github.com/vulkano-rs/vulkano"><i class="fas fa-hands-helping"></i> Contribute</a></li>
+                <li><a target="_blank" href="https://docs.rs/vulkano"><i class="fab fa-rust"></i> API</a></li>
+                <li><a target="_blank" href="https://discord.gg/bncB9W2VDV"><i class="fab fa-discord"></i> Discord</a></li>
+                <li><a target="_blank" href="https://github.com/vulkano-rs/vulkano"><i class="fas fa-hands-helping"></i> Contribute</a></li>
                 <li><a href="/donate"><i class="fas fa-hand-spock"></i> Donate</a></li>
             </ul>
         </header>


### PR DESCRIPTION
Fixed outdated links, removed some outdated example links and added `target="_blank"` to external links.