### PR TITLE
Fixed wrong variable name

### DIFF
--- a/content/guide/buffer_creation/example_operation.md
+++ b/content/guide/buffer_creation/example_operation.md
@@ -66,7 +66,7 @@ let mut builder = AutoCommandBufferBuilder::primary(
 )
 .unwrap();
 
-builder.copy_buffer(source.clone(), dest.clone()).unwrap();
+builder.copy_buffer(source.clone(), destination.clone()).unwrap();
 
 let command_buffer = builder.build().unwrap();
 ```


### PR DESCRIPTION
The code section under '**Command buffers**' contained a call to the variable `dest` which is actually called `destination` when it's defined under '**Creating the buffers**'