### PR TITLE
fix: Range defaults to i32 but shader uses u32

### DIFF
--- a/content/guide/compute_pipeline/compute_intro.md
+++ b/content/guide/compute_pipeline/compute_intro.md
@@ -58,7 +58,9 @@ As a preliminary action we are going to create the buffer that will contain the 
 similar to what we already did twice:
 
 ```rust
-let data_iter = 0 .. 65536;
+use std::ops::Range;
+
+let data_iter: Range<u32> = 0 .. 65536;
 let data_buffer = CpuAccessibleBuffer::from_iter(device.clone(), BufferUsage::all(), false,
                                                  data_iter).expect("failed to create buffer");
 ```


### PR DESCRIPTION
fix: Range defaults to i32 but compute shader uses u32 - types should match