### PR TITLE
fix: PipelineLayout.descriptor_set_layouts renamed

### DIFF
--- a/content/guide/compute_pipeline/descriptor_sets.md
+++ b/content/guide/compute_pipeline/descriptor_sets.md
@@ -40,7 +40,7 @@ use vulkano::descriptor_set::{PersistentDescriptorSet, WriteDescriptorSet};
 
 let layout = compute_pipeline
     .layout()
-    .descriptor_set_layouts()
+    .set_layouts()
     .get(0)
     .unwrap();
 
@@ -53,7 +53,7 @@ let set = PersistentDescriptorSet::new(
 
 In order to create a descriptor set, you'll need to know the layout that it is targeting. We do this by using the "Pipeline" trait
 and calling `.layout()` on our pipeline to obtain the pipeline's layout. Next we'll fetch the layout
-specific to the pass that we want to target by using `.descriptor_set_layouts().get(0)` where zero indicates the
+specific to the pass that we want to target by using `.set_layouts().get(0)` where zero indicates the
 first index of the pass that we are targeting.
 
 Once you have created a descriptor set, you may also use it with other pipelines, as long as the


### PR DESCRIPTION
fix: method PipelineLayout.descriptor_set_layouts() no longer present, use PipelineLayout.set_layouts()