### PR TITLE
fix: bytemuck needs some more traits derived

### DIFF
--- a/content/guide/graphics_pipeline/vertex_shader.md
+++ b/content/guide/graphics_pipeline/vertex_shader.md
@@ -19,7 +19,10 @@ done, the shape of our triangle is going to be a buffer whose content is an arra
 `Vertex` objects.
 
 ```rust
-#[derive(Default, Copy, Clone)]
+use bytemuck::{Pod, Zeroable};
+
+#[derive(Default, Copy, Clone, Pod, Zeroable)]
+#[repr(C)]
 struct Vertex {
     position: [f32; 2],
 }


### PR DESCRIPTION
fix: `Vertex` needs `bytemuck::Pod` and `bytemuck::Zeroable` and `#[repr(C)]`