### PR TITLE
fix: leftover bool type for MyStruct

### DIFF
--- a/content/guide/buffer_creation/buffer_creation.md
+++ b/content/guide/buffer_creation/buffer_creation.md
@@ -109,7 +109,7 @@ For example if `buffer` contains a `MyStruct` (see above):
 let mut content = buffer.write().unwrap();
 // `content` implements `DerefMut` whose target is of type `MyStruct` (the content of the buffer)
 content.a *= 2;
-content.b = false;
+content.b = 9;
 ```
 
 Alternatively, suppose that the content of `buffer` is of type `[u8]` (like with the example that


### PR DESCRIPTION
[Bytemuck does not support `bool` type](https://docs.rs/bytemuck/1.1.0/bytemuck/trait.Pod.html#safety). Changed `b` to `u32` as it is already defined for `MyStruct`