### PR TITLE
Used structs added to use decleration

### DIFF
--- a/content/guide/initialization/device-creation.md
+++ b/content/guide/initialization/device-creation.md
@@ -47,7 +47,7 @@ let queue_family = physical.queue_families()
 We can use it to create the device:
 
 ```rust
-use vulkano::device::{Device, Features};
+use vulkano::device::{Device, DeviceCreateInfo, QueueCreateInfo};
 
 let (device, mut queues) = Device::new(
     physical,


### PR DESCRIPTION
Before:
```rust
use vulkano::device::{Device, Features};
```

After:
```rust
use vulkano::device::{Device, DeviceCreateInfo, QueueCreateInfo};
```

The structs DeviceCreateInfo and QueueCreateInfo are used in the example while the struct Features is not used.